### PR TITLE
config: gitignore all .pass file except .restic.pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# config file
 config.json
+
+# password file
+*.pass
+!.restic.pass


### PR DESCRIPTION
Modify `.gitignore` file to exclude all `.pass` files except `.restic.pass` for default setting

issue: https://github.com/liuminhaw/wrestic-bkp/issues/24