### PR TITLE
fix: ci pack_changelog job changelog file path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          path: checkout-dest
 
       - name: Archive CHANGELOG
         uses: actions/upload-artifact@v3 


### PR DESCRIPTION
# Description
`pack_changelog` no custom path on checkout