### PR TITLE
ci: go build package with CGO option disabled

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Program build
         run: |
-          go build -o ${{ env.BUILD_OUTPUT }}
+          CGO_ENABLED=0 go build -o ${{ env.BUILD_OUTPUT }}
           gzip $BUILD_OUTPUT
 
       - name: Archive built artifact


### PR DESCRIPTION
# Description
Disable CGO in build process with `CGO_ENABLED=0` option